### PR TITLE
enable socket level stats via port 9000

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -79,10 +79,8 @@ properties:
     default: false
   ha_proxy.stats_user:
     description: "User name to authenticate haproxy stats"
-    default: admin
   ha_proxy.stats_password:
     description: "Password to authenticate haproxy stats"
-    default: admin
 
   ha_proxy.backend_servers:
     description: "Array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -27,7 +27,7 @@ properties:
   ha_proxy.internal_only_domains:
     description: "Array of domains for internal-only apps/services (not hostnames for the apps/services)"
     default: []
-  ha_proxy.trusted_domain_cidrs: 
+  ha_proxy.trusted_domain_cidrs:
     description: "Space separated trusted cidr blocks for internal_only_domains"
     default: 0.0.0.0/32
   ha_proxy.ssl_pem:
@@ -73,6 +73,16 @@ properties:
   ha_proxy.queue_timeout:
     description: "Timeout for requests queued waiting for free connection slots (in seconds)"
     default:     30
+
+  ha_proxy.stats_enable:
+    description: "If true, haproxy will enable a socket for stats. You can see the stats on haproxy_ip:9000/haproxy_stats"
+    default: false
+  ha_proxy.stats_user:
+    description: "User name to authenticate haproxy stats"
+    default: admin
+  ha_proxy.stats_password:
+    description: "Password to authenticate haproxy stats"
+    default: admin
 
   ha_proxy.backend_servers:
     description: "Array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -81,6 +81,12 @@ properties:
     description: "User name to authenticate haproxy stats"
   ha_proxy.stats_password:
     description: "Password to authenticate haproxy stats"
+  ha_proxy.stats_uri:
+    description: "URI used to access the stats UI."
+    default: "haproxy_stats"
+  ha_proxy.trusted_stats_cidrs:
+    description: "Trusted ip range that can access the stats UI"
+    default: 0.0.0.0/32
 
   ha_proxy.backend_servers:
     description: "Array of the router IPs acting as the HTTP/TCP backends (should include servers all Availability Zones being used)"

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -24,16 +24,17 @@ defaults
     timeout http-request    <%= p("ha_proxy.request_timeout").to_i    * 1000 %>ms
     timeout queue           <%= p("ha_proxy.queue_timeout").to_i      * 1000 %>ms
 
-  <% if p("ha_proxy.stats_enable") %>
-  listen stats :9000
-      acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
-      mode http
-      stats enable
-      stats hide-version
-      stats realm Haproxy\ Statistics
-      stats uri /<%= p("ha_proxy.stats_uri") %>
-      stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
-  <% end %>
+<% if p("ha_proxy.stats_enable") %>
+listen stats :9000
+    acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
+    http-request deny unless private
+    mode http
+    stats enable
+    stats hide-version
+    stats realm Haproxy\ Statistics
+    stats uri /<%= p("ha_proxy.stats_uri") %>
+    stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
+<% end %>
 
 <%# HTTP Frontend %>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -26,11 +26,12 @@ defaults
 
   <% if p("ha_proxy.stats_enable") %>
   listen stats :9000
+      acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
       mode http
       stats enable
       stats hide-version
       stats realm Haproxy\ Statistics
-      stats uri /haproxy_stats
+      stats uri /<%= p("ha_proxy.stats_uri") %>
       stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
   <% end %>
 

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -24,6 +24,16 @@ defaults
     timeout http-request    <%= p("ha_proxy.request_timeout").to_i    * 1000 %>ms
     timeout queue           <%= p("ha_proxy.queue_timeout").to_i      * 1000 %>ms
 
+  <% if p("ha_proxy.stats_enable") %>
+  listen stats :9000
+      mode http
+      stats enable
+      stats hide-version
+      stats realm Haproxy\ Statistics
+      stats uri /haproxy_stats
+      stats auth <%= p("ha_proxy.stats_user") %>:<%= p("ha_proxy.stats_password") %>
+  <% end %>
+
 <%# HTTP Frontend %>
 
 <% unless p("ha_proxy.disable_http") %>


### PR DESCRIPTION
* This would enable a socket interface for haproxy where you can pull off network level metrics for your haproxy. 
* The UI can be reached with {YOUR_PROXY_IP}:9000/haproxy_stats with the credentials you set.