### PR TITLE
Keepalived support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -19,3 +19,8 @@ haproxy/socat-1.7.3.1.tar.gz:
   object_id: bcc504b7-e970-4469-ad93-d030b082e14c
   sha: a6f1d8ab3e85f565dbe172f33a9be6708dd52ffb
   size: 606049
+keepalived/keepalived-1.2.24.tar.gz:
+  object_id: aa936bbe-fe82-49cc-82c8-99d867e5b4bb
+  sha: !binary |-
+    YTY5YjJjNDA2MjdhOWJkNjk2OThhNTdlODFhOGM4Yzk3ODI2MDI1ZA==
+  size: 601873

--- a/docs/keepalived.md
+++ b/docs/keepalived.md
@@ -1,0 +1,103 @@
+# Purpose of keepalived implementation
+
+Adding support for [keepalived](http://www.keepalived.org/documentation.html) to enable high availability in an haproxy deployment, leveraging the https://en.wikipedia.org/wiki/Virtual_Router_Redundancy_Protocol more formally [RFC 5798](https://tools.ietf.org/html/rfc5798). See [keep-alived man page](https://linux.die.net/man/5/keepalived.conf) for more precision over capabilities of keep-alived as well as the [keep-alived user manual](http://www.keepalived.org/pdf/UserGuide.pdf)
+
+This enables declaring an virtual IP (``keepalived.vip``) that will automatically fail over between the multiple haproxy VMs: the master will initially be the bosh vm for haproxy job instance 0. The default IP addresses assigned by bosh to vms on eth0 are used within the VRRP protocol.
+
+Prereqs:
+ * The haproxy VMs must be within the same broadcast domain, i.e. receive multicast traffic sent to the 224.0.0.18 broadcast and IP protocol number 112.
+* The clients using this VIP must be within the [same broadcast domain](https://en.wikipedia.org/wiki/Broadcast_domain) as the haproxy vms and accepting ARP gratuitious. 
+
+
+# This feature has been successfully tested on the following IAAS :
+* Cloudstack w/ XenServer
+
+
+# Limitations and future enhancements
+* logs collection and monitoring/alerting : keepalived logs are sent to syslog and can t be retrieved using `bosh logs` you have to tail /var/log/syslog to get info
+* Health check period is hardcoded to 2s : we will add parameter for this
+* mcast_src_ip @IP is 224.0.0.18 : we will add parameter for this
+* Not yet email notification : we will add parameter for this
+* Hardcoded VRRP advertisement to 1 S (advert_int) triggering a new VRRP election and fail over. Not yet drain script handling to prevent downtime while bosh upgrades.
+* For the moment, KeepAlived is configured to use broadcast for network communication between nodes. Future versions will be able to use unicast to expose a VIP or control a distinct SDN system such as an AWS ElasticIP (through custom VRRP failover notification scripts)
+
+
+# testing
+## First verification
+* after setting up keepalived.vip parameter, connect to the instance with index 0 of your AZ. BOSH will configure this one as master
+* run `sudo ip a`
+* you should see the VIP (in example above, VIP is set as 10.234.250.201)
+
+```
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 06:c9:f6:00:0a:38 brd ff:ff:ff:ff:ff:ff
+    inet 10.234.250.199/26 brd 10.234.250.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 10.234.250.201/32 scope global eth0
+       valid_lft forever preferred_lft forever
+```
+* The VIP is up, you can perform further testing and access your backend services using the VIP
+
+## Failover scenario
+* Let s stop haproxy on first node by running `monit stop haproxy`
+* Let s run `ip a` on first node
+```
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 06:c9:f6:00:0a:38 brd ff:ff:ff:ff:ff:ff
+    inet 10.234.250.199/26 brd 10.234.250.255 scope global eth0
+       valid_lft forever preferred_lft forever
+```
+* no more VIP, let s look at our second node
+```
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 06:38:ce:00:0a:39 brd ff:ff:ff:ff:ff:ff
+    inet 10.234.250.200/26 brd 10.234.250.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 10.234.250.201/32 scope global eth0
+       valid_lft forever preferred_lft forever
+```
+* It works ! If we look at logs on first node :
+```
+Dec  7 12:47:34 localhost Keepalived_vrrp[4558]: VRRP_Script(check_haproxy) failed
+Dec  7 12:47:34 localhost Keepalived_vrrp[4558]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Effective priority = 101
+Dec  7 12:47:35 localhost Keepalived_vrrp[4558]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received higher prio advert 102
+Dec  7 12:47:35 localhost Keepalived_vrrp[4558]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering BACKUP STATE
+```
+and second node :
+```
+Dec  7 12:47:35 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) forcing a new MASTER election
+Dec  7 12:47:36 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Transition to MASTER STATE
+Dec  7 12:47:37 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering MASTER STATE
+```
+* Same scenario if you stop the master node :
+```
+Dec  7 12:55:52 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received higher prio advert 103
+Dec  7 12:55:52 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering BACKUP STATE
+Dec  7 12:58:22 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Transition to MASTER STATE
+Dec  7 12:58:23 localhost Keepalived_vrrp[4544]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering MASTER STATE
+```
+* If you kill the VM running the master node (using IAAS) :
+```
+Dec  8 14:01:34 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Transition to MASTER STATE
+Dec  8 14:01:35 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering MASTER STATE
+```
+and after restarting the master node :
+```
+Dec  8 14:02:55 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received lower prio advert 101, forcing new election
+Dec  8 14:02:56 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received higher prio advert 103
+Dec  8 14:02:56 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering BACKUP STATE
+```
+* Running the canary on master node :
+master node :
+```
+Dec  8 14:13:20 localhost Keepalived_vrrp[1046]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Effective priority = 101
+```
+
+slave node :
+```
+Dec  8 14:13:24 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Transition to MASTER STATE
+Dec  8 14:13:25 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering MASTER STATE
+Dec  8 14:13:33 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received lower prio advert 101, forcing new election
+Dec  8 14:13:34 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Received higher prio advert 103
+Dec  8 14:13:34 localhost Keepalived_vrrp[11463]: VRRP_Instance(haproxy_keepalived_mysql_infra_check_haproxy) Entering BACKUP STATE
+```

--- a/jobs/keepalived/monit
+++ b/jobs/keepalived/monit
@@ -1,0 +1,6 @@
+check process keepalived
+  with pidfile /var/vcap/sys/run/keepalived/pid
+  start program "/var/vcap/jobs/keepalived/bin/keepalived_ctl start"
+  stop program "/var/vcap/jobs/keepalived/bin/keepalived_ctl stop"
+  group vcap
+

--- a/jobs/keepalived/spec
+++ b/jobs/keepalived/spec
@@ -1,0 +1,27 @@
+---
+name: keepalived
+
+description: "The keepalived job can be used to add a VRRP IP address to enforce HA on haproxy release"
+
+packages:
+- keepalived
+
+templates:
+  keepalived_ctl: 		bin/keepalived_ctl
+  keepalived.config.erb: 	config/keepalived.config
+
+properties:
+  keepalived.vip:
+    description: Virtual IP V4 address that will be given to master 
+  keepalived.healthcheck_name:
+    description: label displayed for the health check. Will appear in keepalive traces e.g. "Keepalived_vrrp[4558] VRRP_Script(check_haproxy) failed"
+    default: check_haproxy
+  keepalived.healthcheck_command:
+    description: when health check fails, this triggers a fail over. The default command checks the haproxy process is still alive.
+    default: killall -0 haproxy
+  keepalived.interface:
+    description: interface keepalived will use to mount the VIP
+    default: eth0
+  keepalived.virtual_router_id:                
+    description : Specifies the VRRP virtual router identifier (VRID)(numerical from 1 to 255). A unique VRID value is needed for each VRRP cluster
+    default: 1

--- a/jobs/keepalived/templates/keepalived.config.erb
+++ b/jobs/keepalived/templates/keepalived.config.erb
@@ -1,0 +1,30 @@
+global_defs {
+	# Keepalived process identifier
+	lvs_id <%= spec.name %> 
+}
+# Healthcheck test to be performed, if rc is different than 0, new master election is required between all the remaining nodes
+vrrp_script <%= p('keepalived.healthcheck_name') %> {
+	script "<%= p('keepalived.healthcheck_command') %>"
+	interval 2
+	weight 2
+}
+# Virtual interface
+# The priority specifies the order in which the assigned interface to take over in a failover
+vrrp_instance <%= spec.name+'_'+p('keepalived.healthcheck_name') %> {
+	<% if spec.bootstrap %>
+	state MASTER
+	priority 101
+	<% else %>
+	state SLAVE
+	priority 100
+	<% end %>
+	interface <%= p('keepalived.interface') %>
+	virtual_router_id <%= p('keepalived.virtual_router_id') %>
+# The virtual ip address shared between the two loadbalancers
+	virtual_ipaddress {
+		<%= p('keepalived.vip') %>
+	}
+	track_script {
+		<%= p('keepalived.healthcheck_name') %>
+	}
+}

--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -1,0 +1,33 @@
+#!/bin/bash
+APP_DIR=/var/vcap/jobs/keepalived
+PKG_DIR=/var/vcap/packages/keepalived
+BIN_DIR=${PKG_DIR}/bin
+SBIN_DIR=${PKG_DIR}/sbin
+CONF_DIR=${APP_DIR}/config
+RUN_DIR=/var/vcap/sys/run/keepalived
+LOG_DIR=/var/vcap/sys/log/keepalived
+PIDFILE=${RUN_DIR}/pid
+
+case $1 in
+
+  start)
+    mkdir -p $RUN_DIR $LOG_DIR
+    chown -R vcap:vcap $RUN_DIR $LOG_DIR
+    echo $$ > $PIDFILE
+	$SBIN_DIR/keepalived \
+		-f $CONF_DIR/keepalived.config \
+		--pid=$PIDFILE \
+		&
+		
+    ;;
+
+  stop)
+    kill -9 -$(cat $PIDFILE)
+    rm -f $PIDFILE
+
+    ;;
+
+  *)
+    echo "Usage: keepalived_ctl {start|stop}" ;;
+
+esac

--- a/packages/keepalived/packaging
+++ b/packages/keepalived/packaging
@@ -1,0 +1,13 @@
+# abort script on any command that exits with a non zero value
+set -e -x
+
+#Source can be downloaded at : http://www.keepalived.org/software/keepalived-1.2.24.tar.gz
+tar xzvf keepalived/keepalived-1.2.24.tar.gz
+cd keepalived-1.2.24/
+
+#compile keepalive
+./configure --prefix=${BOSH_INSTALL_TARGET}
+make 
+make install
+
+

--- a/packages/keepalived/spec
+++ b/packages/keepalived/spec
@@ -1,0 +1,8 @@
+---
+name: keepalived
+
+dependencies: []
+
+files:
+- keepalived/keepalived-1.2.24.tar.gz
+

--- a/templates/example-settings.yml
+++ b/templates/example-settings.yml
@@ -17,3 +17,6 @@ meta:
       keepalive_timeout:    1
       queue_timeout:       30
       accept_proxy: "accept-proxy"
+    keepalived:
+    #vip is the only mandatory parameter
+      vip: '192.168.0.1'

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -49,3 +49,4 @@ networks: (( merge ))
 properties:
   <<: (( merge ))
   ha_proxy: (( meta.properties.ha_proxy ))
+  keepalived: (( meta.properties.keepalived ))


### PR DESCRIPTION
Adding support for [keepalived](http://www.keepalived.org/documentation.html) to enable high availability in an haproxy deployment, leveraging the https://en.wikipedia.org/wiki/Virtual_Router_Redundancy_Protocol more formally [RFC 5798](https://tools.ietf.org/html/rfc5798). See [keep-alived man page](https://linux.die.net/man/5/keepalived.conf) for more precision over capabilities of keep-alived as well as the [keep-alived user manual](http://www.keepalived.org/pdf/UserGuide.pdf)

This enables declaring a virtual IP (``keepalived.vip``) that will automatically fail over between the multiple haproxy VMs: the master will initially be the bosh vm for haproxy job instance 0. The default IP addresses assigned by bosh to vms on eth0 are used within the VRRP protocol.

Notes:
* this PR needs to create a new blob in the cf-community S3 bucket. In order to avoid clean ups if the PR is not merged, we did not yet upload the blob. The corresponding sources are at http://www.keepalived.org/software/keepalived-1.2.24.tar.gz. Let us know if you'd prefer instead us to upload the blob on the Cf community s3 blob and reference it into the PR.
* limitations and future work documented in the  docs/keepalived.md file
* the template jobs.yml was not modified to systematically include the keepalived into the haproxy jobs (as this would trigger systematic enabling od keepalived). 
* The keepalived job may also be collocated with other bosh releases such as the mysql release switchboard (see related discussion https://github.com/cloudfoundry/cf-mysql-release/issues/82#issuecomment-150704953 ). It may make sense to extract the keepalived package and jobs into its own release in the future.
