### PR TITLE
Support haproxy stats socket / socat package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,3 +15,7 @@ haproxy/haproxy-1.6.10.tar.gz:
   object_id: 2bf5332a-f13d-40f7-b6c3-f32afa944275
   sha: 012f4caca3f39999e36229537798122c5f3698ac
   size: 1578385
+haproxy/socat-1.7.3.1.tar.gz:
+  object_id: bcc504b7-e970-4469-ad93-d030b082e14c
+  sha: a6f1d8ab3e85f565dbe172f33a9be6708dd52ffb
+  size: 606049

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -8,6 +8,8 @@ global
     maxconn 64000
     spread-checks 4
     tune.ssl.default-dh-param <%= p("ha_proxy.default_dh_param") %>
+    stats socket /var/vcap/sys/run/haproxy/stats.sock mode 600 level admin
+    stats timeout 2m
 
 defaults
     log global

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,17 +1,28 @@
 # abort script on any command that exit with a non zero value
 set -e
 
+mkdir ${BOSH_INSTALL_TARGET}/bin
+
 echo "Extracting pcre..."
 tar xzf haproxy/pcre-8.36.tar.gz
-cd pcre-8.36
-./configure
-make
-make install
-cd ..
+pushd pcre-8.36
+  ./configure
+  make
+  make install
+popd
+
+echo "Installing socat..."
+tar xzf haproxy/socat-1.7.3.1.tar.gz
+pushd socat-1.7.3.1
+  ./configure
+  make
+  cp socat ${BOSH_INSTALL_TARGET}/bin
+  chmod 755 ${BOSH_INSTALL_TARGET}/bin/socat
+popd
 
 tar xzf haproxy/haproxy-1.6.10.tar.gz
-cd haproxy-1.6.10
-make TARGET=linux2628 USE_OPENSSL=1 USE_STATIC_PCRE=1 USE_ZLIB=1
-mkdir ${BOSH_INSTALL_TARGET}/bin
-cp haproxy ${BOSH_INSTALL_TARGET}/bin/
-chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
+pushd haproxy-1.6.10
+  make TARGET=linux2628 USE_OPENSSL=1 USE_STATIC_PCRE=1 USE_ZLIB=1
+  cp haproxy ${BOSH_INSTALL_TARGET}/bin/
+  chmod 755 ${BOSH_INSTALL_TARGET}/bin/haproxy
+popd

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -3,3 +3,4 @@ name: haproxy
 files:
 - haproxy/haproxy-1.6.10.tar.gz
 - haproxy/pcre-8.36.tar.gz
+- haproxy/socat-1.7.3.1.tar.gz


### PR DESCRIPTION
The haproxy package now comes with socat, and haproxy itself now
instantiates the stats socket in /var/vcap/sys/run/haproxy/stats.sock

Usage is pretty simple:

    echo show errors | /var/vcap/packages/haproxy/bin/socat \
        /var/vcap/sys/run/haproxy/stats.sock -

Fixes #40