### PR TITLE
Add stats_bind parameter support.

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -79,7 +79,7 @@ properties:
     default: false
   ha_proxy.stats_bind:
     description: "Defines to what address should stats be bound to."
-    default: ":9000"
+    default: "*:9000"
   ha_proxy.stats_user:
     description: "User name to authenticate haproxy stats"
   ha_proxy.stats_password:

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -78,7 +78,7 @@ properties:
     description: "If true, haproxy will enable a socket for stats. You can see the stats on haproxy_ip:9000/haproxy_stats"
     default: false
   ha_proxy.stats_bind:
-    description: "Defines to what address should stats be bound to."
+    description: "Define one or several listening addresses and/or ports in a frontend."
     default: "*:9000"
   ha_proxy.stats_user:
     description: "User name to authenticate haproxy stats"

--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -77,6 +77,9 @@ properties:
   ha_proxy.stats_enable:
     description: "If true, haproxy will enable a socket for stats. You can see the stats on haproxy_ip:9000/haproxy_stats"
     default: false
+  ha_proxy.stats_bind:
+    description: "Defines to what address should stats be bound to."
+    default: ":9000"
   ha_proxy.stats_user:
     description: "User name to authenticate haproxy stats"
   ha_proxy.stats_password:

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -28,7 +28,7 @@ defaults
 
 <% if p("ha_proxy.stats_enable") %>
 listen stats
-    bind :9000
+    bind <%= p("ha_proxy.stats_bind") %>
     acl private src <%= p("ha_proxy.trusted_stats_cidrs") %>
     http-request deny unless private
     mode http


### PR DESCRIPTION
Current spec/config causes haproxy to crash before starting properly due to incorrect bind value (:9000)