### PR TITLE
Improved keepalived operability

### DIFF
--- a/jobs/keepalived/monit
+++ b/jobs/keepalived/monit
@@ -1,5 +1,5 @@
 check process keepalived
-  with pidfile /var/vcap/sys/run/keepalived/pid
+  with pidfile /var/vcap/sys/run/keepalived/keepalived.pid
   start program "/var/vcap/jobs/keepalived/bin/keepalived_ctl start"
   stop program "/var/vcap/jobs/keepalived/bin/keepalived_ctl stop"
   group vcap

--- a/jobs/keepalived/spec
+++ b/jobs/keepalived/spec
@@ -20,8 +20,8 @@ properties:
     description: when health check fails, this triggers a fail over. The default command checks the haproxy process is still alive.
     default: killall -0 haproxy
   keepalived.interface:
-    description: interface keepalived will use to mount the VIP
-    default: eth0
+    description: interface keepalived will use to mount the VIP. If set to 'auto', uses the default interface on the VM
+    default: auto
   keepalived.virtual_router_id:                
     description : Specifies the VRRP virtual router identifier (VRID)(numerical from 1 to 255). A unique VRID value is needed for each VRRP cluster
     default: 1

--- a/jobs/keepalived/spec
+++ b/jobs/keepalived/spec
@@ -8,7 +8,7 @@ packages:
 
 templates:
   keepalived_ctl: 		bin/keepalived_ctl
-  keepalived.config.erb: 	config/keepalived.config
+  keepalived.config.erb: 	config/keepalived.config.template
 
 properties:
   keepalived.vip:

--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -85,7 +85,7 @@ case $1 in
         sed "s/interface auto/interface ${interface}/" ${CONF_DIR}/keepalived.config.template > ${CONF_DIR}/keepalived.config
     fi
 
-    $SBIN_DIR/keepalived -l -D \
+    $SBIN_DIR/keepalived -l -D -n \
         -f $CONF_DIR/keepalived.config \
         --pid=$RUN_DIR/keepalived.pid \
         --vrrp_pid=${RUN_DIR}/vrrp.pid \

--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -7,6 +7,66 @@ CONF_DIR=${APP_DIR}/config
 RUN_DIR=/var/vcap/sys/run/keepalived
 LOG_DIR=/var/vcap/sys/log/keepalived
 
+interface_for_ip() {
+    local ip=$1
+    local network=""
+
+    for route in $(ip route show scope link | cut -d " " -f1); do
+        if [[ $(ip_in_network $route $ip) == 0 ]]; then
+            network=$route
+            break
+        fi
+    done
+
+    if [[ -z $network ]]; then
+        echo "Could not determine an interface for requested VIP: $ip"
+        exit 1
+    fi
+
+    interface=$(ip route show scope link | grep "${network}" | cut -d " " -f3)
+    if [[ -z ${interface} ]]; then
+        echo "Could not find the previously found network ${network} in the routing tables. Something is very wrong"
+        exit 1
+    fi
+    echo "${interface}"
+}
+
+binary_ip() {
+    string_ip=$1
+    i=1
+    binary_ip=0
+    for octet in $(echo "$string_ip" | tr -s "." " "); do
+        binary_ip=$(($binary_ip + ($octet<<(32-(8*$i)))))
+        i=$(($i+1))
+    done
+    echo ${binary_ip}
+}
+
+binary_mask() {
+    bits=$1
+    full_mask=$(((2**32)-1))
+    mask=$((((2**32)-1)-((2**(32-$bits))-1)))
+    echo $mask
+}
+
+ip_in_network() {
+    network=$1
+    target_ip=$2
+
+    net_ip=$(echo $network | cut -d "/" -f1)
+    net_mask=$(echo $network | cut -d "/" -f2)
+
+    net_ip_binary=$(binary_ip "$net_ip")
+    target_ip_binary=$(binary_ip "$target_ip")
+    net_mask_binary=$(binary_mask "$net_mask")
+
+    if [[ $(($net_ip_binary&$net_mask_binary)) == $(($target_ip_binary&$net_mask_binary)) ]]; then
+        echo 0
+    else
+        echo 1
+    fi
+}
+
 exec >>${LOG_DIR}/keepalived.log 2>&1
 
 case $1 in
@@ -15,9 +75,14 @@ case $1 in
     echo "Starting keepalived... ($(date))"
     mkdir -p $RUN_DIR $LOG_DIR
     chown -R vcap:vcap $RUN_DIR $LOG_DIR
-    interface=$(ip route get 8.8.8.8 | tr -s "\n" " " | sed 's/.*\dev \(\S\+\).*/\1/')
-    if grep "interface auto" ${CONF_DIR}/keepalived.config > /dev/null; then
-        sed -i "s/interface auto/interface ${interface}/" ${CONF_DIR}/keepalived.config
+
+    interface=$(interface_for_ip <%= p("keepalived.vip") %>)
+    if [[ $? != 0 || -z ${interface} ]]; then
+        echo "Could not autodetect interface to use for <%= p("keepalived.vip") %>. Cannot continue."
+        exit 1
+    fi
+    if grep "interface auto" ${CONF_DIR}/keepalived.config.template > /dev/null; then
+        sed "s/interface auto/interface ${interface}/" ${CONF_DIR}/keepalived.config.template > ${CONF_DIR}/keepalived.config
     fi
 
     $SBIN_DIR/keepalived -l -D \

--- a/jobs/keepalived/templates/keepalived_ctl
+++ b/jobs/keepalived/templates/keepalived_ctl
@@ -6,24 +6,34 @@ SBIN_DIR=${PKG_DIR}/sbin
 CONF_DIR=${APP_DIR}/config
 RUN_DIR=/var/vcap/sys/run/keepalived
 LOG_DIR=/var/vcap/sys/log/keepalived
-PIDFILE=${RUN_DIR}/pid
+
+exec >>${LOG_DIR}/keepalived.log 2>&1
 
 case $1 in
 
   start)
+    echo "Starting keepalived... ($(date))"
     mkdir -p $RUN_DIR $LOG_DIR
     chown -R vcap:vcap $RUN_DIR $LOG_DIR
-    echo $$ > $PIDFILE
-	$SBIN_DIR/keepalived \
-		-f $CONF_DIR/keepalived.config \
-		--pid=$PIDFILE \
-		&
-		
+    interface=$(ip route get 8.8.8.8 | tr -s "\n" " " | sed 's/.*\dev \(\S\+\).*/\1/')
+    if grep "interface auto" ${CONF_DIR}/keepalived.config > /dev/null; then
+        sed -i "s/interface auto/interface ${interface}/" ${CONF_DIR}/keepalived.config
+    fi
+
+    $SBIN_DIR/keepalived -l -D \
+        -f $CONF_DIR/keepalived.config \
+        --pid=$RUN_DIR/keepalived.pid \
+        --vrrp_pid=${RUN_DIR}/vrrp.pid \
+        --checkers_pid=${RUN_DIR}/vrrp.pid \
+        >> ${LOG_DIR}/keepalived.log 2>&1 &
     ;;
 
   stop)
-    kill -9 -$(cat $PIDFILE)
-    rm -f $PIDFILE
+    echo "Stopping keepalived... ($(date))"
+    for PIDFILE in ${RUN_DIR}/*.pid; do
+        kill -9 -$(cat $PIDFILE)
+        rm -f $PIDFILE
+    done
 
     ;;
 


### PR DESCRIPTION
- Log messages from the startup/shutdown, of keepalived
  as well as keepalived itself go to /var/vcap/sys/log/keepalived.log
- The vrrp + checkers pid files are now located in /var/vcap/sys/run
- If the `keepalived.interface` property is set to `auto`, the job
  will now auto-detect the default interface of the VM, and use that.